### PR TITLE
Add support for using as a custom merge driver

### DIFF
--- a/merge-fmt-mergetool-help.txt
+++ b/merge-fmt-mergetool-help.txt
@@ -17,6 +17,9 @@ OPTIONS
            `pager', `groff' or `plain'. With `auto', the format is `pager` or
            `plain' whenever the TERM env var is `dumb' or undefined.
 
+       --name=<result-name>
+           pathname in which the merged result will be stored
+
        -o <output-to>
 
        --ocamlformat=VAL

--- a/src/fmters.ml
+++ b/src/fmters.ml
@@ -7,26 +7,21 @@ type config =
 
 type t = string
 
-let ocamlformat ~bin =
+let ocamlformat ~bin ~name =
   sprintf
-    "%s -i --disable-outside-detected-project"
+    "%s -i --disable-outside-detected-project%s"
     (Option.value ~default:"ocamlformat" bin)
-
-let ocp_indent ~bin = sprintf "%s -i" (Option.value ~default:"ocp-indent" bin)
+    (Option.value_map ~default:"" ~f:(fun name -> " --name=" ^ name) name)
 
 let refmt ~bin = sprintf "%s --inplace" (Option.value ~default:"refmt" bin)
 
-let find ~config ~filename =
+let find ~config ~filename ~name =
+  let filename = Option.value ~default:filename name in
   match Caml.Filename.extension filename, config with
-  | (".ml" | ".mli"), {ocamlformat_path; _} -> Some (ocamlformat ~bin:ocamlformat_path)
+  | (".ml" | ".mli"), {ocamlformat_path; _} ->
+      Some (ocamlformat ~bin:ocamlformat_path ~name)
   | (".re" | ".rei"), {refmt_path; _} -> Some (refmt ~bin:refmt_path)
   | _ -> None
-
-let ocamlformat = ocamlformat ~bin:None
-
-let ocp_indent = ocp_indent ~bin:None
-
-let refmt = refmt ~bin:None
 
 let run t ~echo ~filename = system ~echo "%s %s" t filename
 

--- a/src/fmters.mli
+++ b/src/fmters.mli
@@ -4,13 +4,7 @@ type config
 
 type t
 
-val ocamlformat : t
-
-val ocp_indent : t
-
-val refmt : t
-
-val find : config:config -> filename:string -> t option
+val find : config:config -> filename:string -> name:string option -> t option
 
 val run : t -> echo:bool -> filename:string -> (unit, unit) Result.t
 

--- a/src/merge_cmd.ml
+++ b/src/merge_cmd.ml
@@ -9,12 +9,12 @@ let debug fmt =
   then Printf.ksprintf (fun _ -> ()) fmt
   else Printf.ksprintf (Out_channel.fprintf (Lazy.force debug_oc) "%s") fmt
 
-let merge config echo current base other output =
+let merge config echo current base other output name =
   match current, base, other with
   | (None | Some ""), _, _ | _, (None | Some ""), _ | _, _, (None | Some "") ->
       Caml.exit 1
   | Some current, Some base, Some other -> (
-    match Fmters.find ~config ~filename:current with
+    match Fmters.find ~config ~filename:current ~name with
     | None ->
         debug "Couldn't find a formatter for %s\n%!" current;
         system_respect_exit ~echo "git merge-file %s %s %s" current base other
@@ -66,6 +66,18 @@ let cmd =
     let doc = "" in
     Arg.(value & opt (some file) None & info ["o"] ~docv:"<output-to>" ~doc)
   in
+  let result_name =
+    let doc = "pathname in which the merged result will be stored" in
+    Arg.(value & opt (some file) None & info ["name"] ~docv:"<result-name>" ~doc)
+  in
   let doc = "git mergetool" in
-  ( Term.(const merge $ Fmters.Flags.t $ Flags.echo $ current $ base $ other $ output)
+  ( Term.(
+      const merge
+      $ Fmters.Flags.t
+      $ Flags.echo
+      $ current
+      $ base
+      $ other
+      $ output
+      $ result_name)
   , Term.info ~doc "mergetool" )

--- a/src/resolve_cmd.ml
+++ b/src/resolve_cmd.ml
@@ -100,7 +100,7 @@ let resolve config echo () =
   Map.iteri all ~f:(fun ~key:filename ~data:versions ->
       match versions with
       | Ok versions -> (
-        match Fmters.find ~config ~filename with
+        match Fmters.find ~config ~filename ~name:None with
         | Some formatter ->
             let n1 = conflict ~filename in
             Result.bind (fix ~echo ~filename ~versions ~formatter) ~f:(fun () ->


### PR DESCRIPTION
This PR adds enough support to use merge-fmt as a git custom merge
driver. This is basically just support for passing the filename of the
final merge result to the formatter so that the correct config can be
used (and to avoid problems due to the absence of file extensions on
the temporary files).

This requires https://github.com/ocaml-ppx/ocamlformat/pull/740 so
that ocamlformat will accept `--name` with `--inplace`.

See
https://git-scm.com/docs/gitattributes#_defining_a_custom_merge_driver
for the docs on how to configure this, but basically adding
```
[merge "mergefmt"]
	name = merge-fmt driver
	driver = merge-fmt mergetool --base=%O --current=%A --other=%B -o %A --name=%P
[merge]
	tool = mergefmt
	default = mergefmt
```
to `.git/config` causes regular merge operations done by git, such as
when rebasing, to use `merge-fmt`.