### PR TITLE
Add support for dune

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add support of dune formatter. (#3)
+
 ## 0.1 (2019-02-19)
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ code formatters.
 `merge-fmt` currently only knows about the following formatters:
 - [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) for OCaml.
 - [refmt](https://github.com/facebook/reason) for reason.
+- [dune](https://github.com/ocaml/dune) for dune.
 
 Note that supporting new code formatters is trivial.
 

--- a/merge-fmt-help.txt
+++ b/merge-fmt-help.txt
@@ -17,6 +17,9 @@ COMMANDS
            Register the [merge-fmt] mergetool in git
 
 OPTIONS
+       --dune=VAL
+           dune path
+
        --echo
            Echo all commands.
 

--- a/merge-fmt-mergetool-help.txt
+++ b/merge-fmt-mergetool-help.txt
@@ -9,6 +9,9 @@ OPTIONS
 
        --current=<current-file>
 
+       --dune=VAL
+           dune path
+
        --echo
            Echo all commands.
 

--- a/src/fmters.ml
+++ b/src/fmters.ml
@@ -16,11 +16,11 @@ let ocamlformat ~bin ~name =
 
 let refmt ~bin = sprintf "%s --inplace" (Option.value ~default:"refmt" bin)
 
-let dune ~bin ~filename =
+let dune ~bin =
   (* redirection as format-dune-file doesn't have an inplace option *)
-  sprintf "%s format-dune-file -- %s > "
+  sprintf
+    {|sp() { tmpf=$(mktemp); cat > "$tmpf"; mv "$tmpf" "$1"; }; dfmt() { %s format-dune-file "$1" | sp "$1"; }; dfmt|}
     (Option.value ~default:"dune" bin)
-    filename
 
 let find ~config ~filename ~name =
   let filename = Option.value ~default:filename name in
@@ -29,7 +29,7 @@ let find ~config ~filename ~name =
       Some (ocamlformat ~bin:ocamlformat_path ~name)
   | _, (".re" | ".rei"), { refmt_path; _ } -> Some (refmt ~bin:refmt_path)
   | ("dune" | "dune-project" | "dune-workspace"), "", { dune_path; _ } ->
-      Some (dune ~bin:dune_path ~filename)
+      Some (dune ~bin:dune_path)
   | _ -> None
 
 let run t ~echo ~filename = system ~echo "%s %s" t filename

--- a/src/resolve_cmd.ml
+++ b/src/resolve_cmd.ml
@@ -125,7 +125,9 @@ let resolve config echo () =
                 ~f:(fun () -> git_add ~echo ~filename)
               |> (ignore : (unit, unit) Result.t -> unit);
               let n2 = conflict ~filename in
-              eprintf "Resolved %d/%d %s\n%!" (n1 - n2) n1 filename
+              if n2 > n1
+              then eprintf "Resolved ?? %s\n%!" filename
+              else eprintf "Resolved %d/%d %s\n%!" (n1 - n2) n1 filename
           | None -> eprintf "Ignore %s (no formatter register)\n%!" filename)
       | Error reason -> eprintf "Ignore %s (%s)\n%!" filename reason);
   let all = ls ~echo () in

--- a/src/resolve_cmd.ml
+++ b/src/resolve_cmd.ml
@@ -67,8 +67,10 @@ let show ~echo version versions =
 
 let create_tmp ~echo fn version versions =
   let content = show ~echo version versions in
-  let ext = Caml.Filename.extension fn
-  and base = Caml.Filename.chop_extension fn in
+  let ext = Caml.Filename.extension fn in
+  let base =
+    if String.equal ext "" then fn else Caml.Filename.chop_extension fn
+  in
   let fn' = sprintf "%s.%s%s" base (string_of_version version) ext in
   let oc = Out_channel.create fn' in
   Out_channel.output_string oc content;

--- a/test/merge_dune.ml
+++ b/test/merge_dune.ml
@@ -156,8 +156,7 @@ let%expect_test "custom merge tool" =
       git_branch "old_branch1";
 
       system "git rebase branch2 -q";
-      [%expect
-        {| |}];
+      [%expect {| |}];
       system "%s" merge_fmt;
       print_file "dune";
       [%expect

--- a/test/merge_dune.ml
+++ b/test/merge_dune.ml
@@ -50,14 +50,14 @@ let%expect_test "default merge tool" =
 
       write "dune"
         {|
-(executable
- (name bbbb)
- (libraries unix))
-
 (alias
  (name runtest)
  (action
   (diff rebase.diff rebase.diff.gen)))
+
+(executable
+ (name bbbb)
+ (libraries unix))
 |};
 
       git_commit "third commit (fork)";
@@ -142,14 +142,14 @@ let%expect_test "custom merge tool" =
 
       write "dune"
         {|
-(executable
- (name bbbb)
- (libraries unix))
-
 (alias
  (name runtest)
  (action
   (diff rebase.diff rebase.diff.gen)))
+
+(executable
+ (name bbbb)
+ (libraries unix))
 |};
       git_commit "third commit (fork)";
       git_branch "old_branch1";
@@ -157,7 +157,15 @@ let%expect_test "custom merge tool" =
       system "git rebase branch2 -q";
       [%expect
         {|
-        dropping a5a03b549f1159aac7629b550009dab46c7a42e0 third commit (fork) -- patch contents already upstream |}];
+        Auto-merging dune
+        CONFLICT (content): Merge conflict in dune
+        error: could not apply 2e00bc1... second commit (fork)
+        hint: Resolve all conflicts manually, mark them as resolved with
+        hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
+        hint: You can instead skip this commit: run "git rebase --skip".
+        hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
+        Could not apply 2e00bc1... second commit (fork)
+        Exit with 1 |}];
       print_file "dune";
       [%expect
         {|

--- a/test/merge_dune.ml
+++ b/test/merge_dune.ml
@@ -15,22 +15,23 @@ let%expect_test "default merge tool" =
       git_branch "branch1";
 
       (* add public name *)
-      write "dune"
-        {|
+      if false
+      then (
+        write "dune"
+          {|
 (executable
 (name aaaa)
 (libraries unix)
 (public_name pppp))
 |};
-      git_commit "second commit";
+        git_commit "second commit");
 
       (* add library *)
       write "dune"
         {|
 (executable
 (name aaaa)
-(libraries unix)
-(public_name pppp))
+(libraries unix))
 
 (library
 (name liblib))
@@ -82,8 +83,7 @@ let%expect_test "default merge tool" =
         (executable
         <<<<<<< HEAD
         (name aaaa)
-        (libraries unix)
-        (public_name pppp))
+        (libraries unix))
 
         (library
         (name liblib))
@@ -107,22 +107,23 @@ let%expect_test "custom merge tool" =
       git_branch "branch1";
 
       (* add public name *)
-      write "dune"
-        {|
+      if false
+      then (
+        write "dune"
+          {|
 (executable
 (name aaaa)
 (libraries unix)
 (public_name pppp))
 |};
-      git_commit "second commit";
+        git_commit "second commit");
 
       (* add library *)
       write "dune"
         {|
 (executable
 (name aaaa)
-(libraries unix)
-(public_name pppp))
+(libraries unix))
 
 (library
 (name liblib))
@@ -156,32 +157,22 @@ let%expect_test "custom merge tool" =
 
       system "git rebase branch2 -q";
       [%expect
-        {|
-        Auto-merging dune
-        CONFLICT (content): Merge conflict in dune
-        error: could not apply 2e00bc1... second commit (fork)
-        hint: Resolve all conflicts manually, mark them as resolved with
-        hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
-        hint: You can instead skip this commit: run "git rebase --skip".
-        hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
-        Could not apply 2e00bc1... second commit (fork)
-        Exit with 1 |}];
+        {| |}];
       system "%s" merge_fmt;
       print_file "dune";
       [%expect
         {|
-        Resolved -1/0 dune
+        Nothing to resolve
         Exit with 1
         File dune
-        (executable
-        <<<<<<< dune.ours
-         (name aaaa)
-         (libraries unix)
-         (public_name pppp))
+        (alias
+         (name runtest)
+         (action
+          (diff rebase.diff rebase.diff.gen)))
 
-        (library
-         (name liblib))
-        =======
+        (executable
          (name bbbb)
          (libraries unix))
-        >>>>>>> dune.theirs |}])
+
+        (library
+         (name liblib)) |}])

--- a/test/merge_dune.ml
+++ b/test/merge_dune.ml
@@ -1,0 +1,171 @@
+open! Base
+open! Stdio
+open! Common
+
+let%expect_test "default merge tool" =
+  within_temp_dir (fun () ->
+      git_init ();
+
+      write "dune" {|
+(executable
+(name aaaa)
+(libraries unix))
+|};
+      git_commit "first commit";
+      git_branch "branch1";
+
+      (* add public name *)
+      write "dune"
+        {|
+(executable
+(name aaaa)
+(libraries unix)
+(public_name pppp))
+|};
+      git_commit "second commit";
+
+      (* add library *)
+      write "dune"
+        {|
+(executable
+(name aaaa)
+(libraries unix)
+(public_name pppp))
+
+(library
+(name liblib))
+|};
+      git_commit "third commit";
+      git_branch "branch2";
+
+      git_checkout "branch1";
+      [%expect {| Switched to branch 'branch1' |}];
+      (* change name to b, reformat *)
+      write "dune" {|
+(executable
+ (name bbbb)
+ (libraries unix))
+|};
+      git_commit "second commit (fork)";
+
+      write "dune"
+        {|
+(executable
+ (name bbbb)
+ (libraries unix))
+
+(alias
+ (name runtest)
+ (action
+  (diff rebase.diff rebase.diff.gen)))
+|};
+
+      git_commit "third commit (fork)";
+      git_branch "old_branch1";
+      system "git rebase branch2 -q";
+      [%expect
+        {|
+        Auto-merging dune
+        CONFLICT (content): Merge conflict in dune
+        error: could not apply 2e00bc1... second commit (fork)
+        hint: Resolve all conflicts manually, mark them as resolved with
+        hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
+        hint: You can instead skip this commit: run "git rebase --skip".
+        hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
+        Could not apply 2e00bc1... second commit (fork)
+        Exit with 1 |}];
+      print_file "dune";
+      [%expect
+        {|
+        File dune
+
+        (executable
+        <<<<<<< HEAD
+        (name aaaa)
+        (libraries unix)
+        (public_name pppp))
+
+        (library
+        (name liblib))
+        =======
+         (name bbbb)
+         (libraries unix))
+        >>>>>>> 2e00bc1 (second commit (fork)) |}])
+
+let%expect_test "custom merge tool" =
+  within_temp_dir (fun () ->
+      git_init ();
+      system "%s setup-merge --merge-fmt-path %s --update" merge_fmt merge_fmt;
+      [%expect {||}];
+
+      write "dune" {|
+(executable
+(name aaaa)
+(libraries unix))
+|};
+      git_commit "first commit";
+      git_branch "branch1";
+
+      (* add public name *)
+      write "dune"
+        {|
+(executable
+(name aaaa)
+(libraries unix)
+(public_name pppp))
+|};
+      git_commit "second commit";
+
+      (* add library *)
+      write "dune"
+        {|
+(executable
+(name aaaa)
+(libraries unix)
+(public_name pppp))
+
+(library
+(name liblib))
+|};
+      git_commit "third commit";
+      git_branch "branch2";
+
+      git_checkout "branch1";
+      [%expect {| Switched to branch 'branch1' |}];
+      (* change name to b, reformat *)
+      write "dune" {|
+(executable
+ (name bbbb)
+ (libraries unix))
+|};
+      git_commit "second commit (fork)";
+
+      write "dune"
+        {|
+(executable
+ (name bbbb)
+ (libraries unix))
+
+(alias
+ (name runtest)
+ (action
+  (diff rebase.diff rebase.diff.gen)))
+|};
+      git_commit "third commit (fork)";
+      git_branch "old_branch1";
+
+      system "git rebase branch2 -q";
+      [%expect
+        {|
+        dropping a5a03b549f1159aac7629b550009dab46c7a42e0 third commit (fork) -- patch contents already upstream |}];
+      print_file "dune";
+      [%expect
+        {|
+        File dune
+        (executable
+         (name aaaa)
+         (libraries unix)
+         (public_name pppp))
+
+        (library
+         (name liblib)) |}])

--- a/test/merge_dune.ml
+++ b/test/merge_dune.ml
@@ -166,14 +166,22 @@ let%expect_test "custom merge tool" =
         hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
         Could not apply 2e00bc1... second commit (fork)
         Exit with 1 |}];
+      system "%s" merge_fmt;
       print_file "dune";
       [%expect
         {|
+        Resolved -1/0 dune
+        Exit with 1
         File dune
         (executable
+        <<<<<<< dune.ours
          (name aaaa)
          (libraries unix)
          (public_name pppp))
 
         (library
-         (name liblib)) |}])
+         (name liblib))
+        =======
+         (name bbbb)
+         (libraries unix))
+        >>>>>>> dune.theirs |}])

--- a/test/rebase.diff
+++ b/test/rebase.diff
@@ -28,19 +28,20 @@
 ---
 >           }
 >         >>>>>>> 6070a8f (second commit (fork)) |}];
-59,62c69
+59,62c69,70
 <       [%expect
 <         {|
 <         Ignore a.ml (not a 3-way merge)
 <         Exit with 1 |}];
 ---
->       [%expect {| Resolved 1/1 b.ml |}];
-66,67c73
+>       [%expect {|
+>         Resolved 1/1 b.ml |}];
+66,67c74
 <         DU File a.ml
 < 
 ---
 >         M File b.ml
-69,71c75,78
+69,71c76,79
 <           { a : int option;
 <             b : string;
 <             c : float;
@@ -49,7 +50,7 @@
 >           ; b : string
 >           ; c : float
 >           ; d : unit option
-76,79c83,84
+76,79c84,85
 <         a.ml: needs merge
 <         You must edit all merge conflicts and then
 <         mark them as resolved using git add

--- a/test/rebase_b.ml
+++ b/test/rebase_b.ml
@@ -66,7 +66,8 @@ type t =
           }
         >>>>>>> 6070a8f (second commit (fork)) |}];
       resolve ();
-      [%expect {| Resolved 1/1 b.ml |}];
+      [%expect {|
+        Resolved 1/1 b.ml |}];
       print_status ();
       [%expect
         {|

--- a/test/resolve1.ml
+++ b/test/resolve1.ml
@@ -149,7 +149,8 @@ type t =
           | A
           | B of int |}];
       resolve ();
-      [%expect {| Resolved 1/1 b.ml |}];
+      [%expect {|
+        Resolved 1/1 b.ml |}];
       print_status ();
       [%expect
         {|

--- a/test/resolve2.ml
+++ b/test/resolve2.ml
@@ -69,7 +69,8 @@ type t =
           }
         >>>>>>> ead71ee (second commit (fork)):a.ml |}];
       resolve ();
-      [%expect {| Resolved 1/1 b.ml |}];
+      [%expect {|
+        Resolved 1/1 b.ml |}];
       print_status ();
       [%expect
         {|


### PR DESCRIPTION
dune has the ability to format its files. Adding support through the `format-dune-file` command, even though it's [not perfect](https://github.com/ocaml/dune/issues/3516).

I can drop the ocamlformat change if necessary, or put it in a different PR. It was easier to have it when developing with a modern ocaml (4.14)

This work is sponsored by Ahrefs.