### PR TITLE
Tests: disable global git configuration

### DIFF
--- a/test/common.ml
+++ b/test/common.ml
@@ -75,9 +75,11 @@ let within_temp_dir ?(links = []) f =
   with_temp_dir (fun temp_dir ->
       (* disable all external git configuration configuration *)
       Core_unix.putenv ~key:"GIT_CONFIG_NOSYSTEM" ~data:"1";
-      Core_unix.putenv ~key:"GIT_CONFIG" ~data:"/dev/null";
-      Core_unix.putenv ~key:"HOME" ~data:"/dev/null";
-      Core_unix.putenv ~key:"XDG_CONFIG_HOME" ~data:"/dev/null";
+      Core_unix.putenv ~key:"GIT_CONFIG_NOGLOBAL" ~data:"1";
+
+      Core_unix.unsetenv "GIT_CONFIG";
+      Core_unix.unsetenv "HOME";
+      Core_unix.unsetenv "XDG_CONFIG_HOME";
 
       Core_unix.putenv ~key:"GIT_COMMITTER_NAME" ~data:"John Doe";
       Core_unix.putenv ~key:"GIT_COMMITTER_DATE" ~data:"2019-01-01 00:00";

--- a/test/common.ml
+++ b/test/common.ml
@@ -73,7 +73,17 @@ let with_temp_dir f =
 let within_temp_dir ?(links = []) f =
   let cwd = Unix.getcwd () in
   with_temp_dir (fun temp_dir ->
+      (* disable all external git configuration configuration *)
+      Core_unix.putenv ~key:"GIT_CONFIG_NOSYSTEM" ~data:"1";
+      Core_unix.putenv ~key:"GIT_CONFIG" ~data:"/dev/null";
+      Core_unix.putenv ~key:"HOME" ~data:"/dev/null";
+      Core_unix.putenv ~key:"XDG_CONFIG_HOME" ~data:"/dev/null";
+
+      Core_unix.putenv ~key:"GIT_COMMITTER_NAME" ~data:"John Doe";
       Core_unix.putenv ~key:"GIT_COMMITTER_DATE" ~data:"2019-01-01 00:00";
+      Core_unix.putenv ~key:"GIT_COMMITTER_EMAIL" ~data:"johndoe@doe.com";
+      Core_unix.putenv ~key:"GIT_AUTHOR_NAME" ~data:"John Doe";
+      Core_unix.putenv ~key:"GIT_AUTHOR_EMAIL" ~data:"johndoe@doe.com";
       Core_unix.putenv ~key:"GIT_AUTHOR_DATE" ~data:"2019-01-01 00:00";
       Core_unix.putenv ~key:"GIT_EDITOR" ~data:"true";
       let path_var = "PATH" in

--- a/test/merge.ml
+++ b/test/merge.ml
@@ -76,12 +76,12 @@ type t =
         {|
         Auto-merging b.ml
         CONFLICT (content): Merge conflict in b.ml
-        error: could not apply 12ef546... second commit (fork)
+        error: could not apply ac9f205... second commit (fork)
         hint: Resolve all conflicts manually, mark them as resolved with
         hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
         hint: You can instead skip this commit: run "git rebase --skip".
         hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
-        Could not apply 12ef546... second commit (fork)
+        Could not apply ac9f205... second commit (fork)
         Exit with 1 |}];
       print_file "b.ml";
       [%expect
@@ -101,7 +101,7 @@ type t =
             ; b : string
             ; c : float
             }
-          >>>>>>> 12ef546 (second commit (fork)):a.ml |}])
+          >>>>>>> ac9f205 (second commit (fork)):a.ml |}])
 
 let%expect_test "custom merge tool" =
   within_temp_dir (fun () ->

--- a/test/mergetool.ml
+++ b/test/mergetool.ml
@@ -76,12 +76,12 @@ type t =
         {|
         Auto-merging b.ml
         CONFLICT (content): Merge conflict in b.ml
-        error: could not apply 12ef546... second commit (fork)
+        error: could not apply ac9f205... second commit (fork)
         hint: Resolve all conflicts manually, mark them as resolved with
         hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
         hint: You can instead skip this commit: run "git rebase --skip".
         hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
-        Could not apply 12ef546... second commit (fork)
+        Could not apply ac9f205... second commit (fork)
         Exit with 1 |}];
       print_status ();
       [%expect
@@ -101,7 +101,7 @@ type t =
             ; b : string
             ; c : float
             }
-          >>>>>>> 12ef546 (second commit (fork)):a.ml |}];
+          >>>>>>> ac9f205 (second commit (fork)):a.ml |}];
       system "git mergetool --tool mergefmt -y";
       system "git clean -f";
       [%expect
@@ -130,16 +130,16 @@ type t =
       system "git rebase --continue";
       [%expect
         {|
-        [detached HEAD 38f05c7] second commit (fork)
+        [detached HEAD 6a9624f] second commit (fork)
          1 file changed, 9 insertions(+), 6 deletions(-)
         Auto-merging b.ml
         CONFLICT (content): Merge conflict in b.ml
-        error: could not apply 7e70a06... third commit (fork)
+        error: could not apply 35725a2... third commit (fork)
         hint: Resolve all conflicts manually, mark them as resolved with
         hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
         hint: You can instead skip this commit: run "git rebase --skip".
         hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
-        Could not apply 7e70a06... third commit (fork)
+        Could not apply 35725a2... third commit (fork)
         Exit with 1 |}];
       print_status ();
       [%expect
@@ -151,7 +151,7 @@ type t =
         type b = int
 
 
-        >>>>>>> 7e70a06 (third commit (fork)):a.ml
+        >>>>>>> 35725a2 (third commit (fork)):a.ml
         type t =
           { a : int option
           ; b : string
@@ -190,6 +190,7 @@ type t =
           | A
           | B of int |}];
       system "git rebase --continue";
-      [%expect {|
-        [detached HEAD d0f3d71] third commit (fork)
+      [%expect
+        {|
+        [detached HEAD 392acaf] third commit (fork)
          1 file changed, 2 insertions(+) |}])

--- a/test/partial.ml
+++ b/test/partial.ml
@@ -66,12 +66,12 @@ let x = 5
         {|
         Auto-merging b.ml
         CONFLICT (content): Merge conflict in b.ml
-        error: could not apply 48173d8... second prime
+        error: could not apply 8330ba8... second prime
         hint: Resolve all conflicts manually, mark them as resolved with
         hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
         hint: You can instead skip this commit: run "git rebase --skip".
         hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
-        Could not apply 48173d8... second prime
+        Could not apply 8330ba8... second prime
         Exit with 1 |}];
       print_status ();
       [%expect
@@ -89,7 +89,7 @@ let x = 5
           ; b : string
           ; c : float
           }
-        >>>>>>> 48173d8 (second prime):a.ml
+        >>>>>>> 8330ba8 (second prime):a.ml
 
         let y = 0
 
@@ -98,7 +98,7 @@ let x = 5
         let x = 1
         =======
         let x = 5
-        >>>>>>> 48173d8 (second prime):a.ml |}];
+        >>>>>>> 8330ba8 (second prime):a.ml |}];
       resolve ();
       print_status ();
       [%expect
@@ -170,6 +170,7 @@ let x = 5
       system "git add b.ml";
       [%expect {||}];
       system "git rebase --continue";
-      [%expect {|
-        [detached HEAD 730f3dc] second prime
+      [%expect
+        {|
+        [detached HEAD 6adfc81] second prime
          1 file changed, 10 insertions(+), 5 deletions(-) |}])

--- a/test/rebase.diff
+++ b/test/rebase.diff
@@ -4,16 +4,16 @@
 >       [%expect {|
 >         no changes |}];
 40,41c44,46
-<         CONFLICT (modify/delete): a.ml deleted in HEAD and modified in 88f7eca (second commit (fork)).  Version 88f7eca (second commit (fork)) of a.ml left in tree.
-<         error: could not apply 88f7eca... second commit (fork)
+<         CONFLICT (modify/delete): a.ml deleted in HEAD and modified in 790c947 (second commit (fork)).  Version 790c947 (second commit (fork)) of a.ml left in tree.
+<         error: could not apply 790c947... second commit (fork)
 ---
 >         Auto-merging b.ml
 >         CONFLICT (content): Merge conflict in b.ml
->         error: could not apply 5c03ec7... second commit (fork)
+>         error: could not apply b7287b5... second commit (fork)
 46c51
-<         Could not apply 88f7eca... second commit (fork)
+<         Could not apply 790c947... second commit (fork)
 ---
->         Could not apply 5c03ec7... second commit (fork)
+>         Could not apply b7287b5... second commit (fork)
 51c56
 <         DU File a.ml
 ---
@@ -27,7 +27,7 @@
 <           } |}];
 ---
 >           }
->         >>>>>>> 5c03ec7 (second commit (fork)) |}];
+>         >>>>>>> b7287b5 (second commit (fork)) |}];
 59,62c69
 <       [%expect
 <         {|
@@ -49,14 +49,11 @@
 >           ; b : string
 >           ; c : float
 >           ; d : unit option
-74,79c81,83
-<       [%expect
-<         {|
+76,79c83,84
 <         a.ml: needs merge
 <         You must edit all merge conflicts and then
 <         mark them as resolved using git add
 <         Exit with 1 |}])
 ---
->       [%expect {|
->         [detached HEAD 82c7adb] second commit (fork)
+>         [detached HEAD 02057b4] second commit (fork)
 >          1 file changed, 6 insertions(+), 3 deletions(-) |}])

--- a/test/rebase_a.ml
+++ b/test/rebase_a.ml
@@ -37,13 +37,13 @@ type t =
       system "git rebase branch2 -q";
       [%expect
         {|
-        CONFLICT (modify/delete): a.ml deleted in HEAD and modified in 88f7eca (second commit (fork)).  Version 88f7eca (second commit (fork)) of a.ml left in tree.
-        error: could not apply 88f7eca... second commit (fork)
+        CONFLICT (modify/delete): a.ml deleted in HEAD and modified in 790c947 (second commit (fork)).  Version 790c947 (second commit (fork)) of a.ml left in tree.
+        error: could not apply 790c947... second commit (fork)
         hint: Resolve all conflicts manually, mark them as resolved with
         hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
         hint: You can instead skip this commit: run "git rebase --skip".
         hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
-        Could not apply 88f7eca... second commit (fork)
+        Could not apply 790c947... second commit (fork)
         Exit with 1 |}];
       print_status ();
       [%expect

--- a/test/rebase_b.ml
+++ b/test/rebase_b.ml
@@ -43,12 +43,12 @@ type t =
         {|
         Auto-merging b.ml
         CONFLICT (content): Merge conflict in b.ml
-        error: could not apply 5c03ec7... second commit (fork)
+        error: could not apply b7287b5... second commit (fork)
         hint: Resolve all conflicts manually, mark them as resolved with
         hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
         hint: You can instead skip this commit: run "git rebase --skip".
         hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
-        Could not apply 5c03ec7... second commit (fork)
+        Could not apply b7287b5... second commit (fork)
         Exit with 1 |}];
       print_status ();
       [%expect
@@ -64,7 +64,7 @@ type t =
             b : string;
             c : float;
           }
-        >>>>>>> 5c03ec7 (second commit (fork)) |}];
+        >>>>>>> b7287b5 (second commit (fork)) |}];
       resolve ();
       [%expect {| Resolved 1/1 b.ml |}];
       print_status ();
@@ -78,6 +78,7 @@ type t =
           ; d : unit option
           } |}];
       system "git rebase --continue";
-      [%expect {|
-        [detached HEAD 82c7adb] second commit (fork)
+      [%expect
+        {|
+        [detached HEAD 02057b4] second commit (fork)
          1 file changed, 6 insertions(+), 3 deletions(-) |}])

--- a/test/resolve1.ml
+++ b/test/resolve1.ml
@@ -71,12 +71,12 @@ type t =
         {|
         Auto-merging b.ml
         CONFLICT (content): Merge conflict in b.ml
-        error: could not apply 12ef546... second commit (fork)
+        error: could not apply ac9f205... second commit (fork)
         hint: Resolve all conflicts manually, mark them as resolved with
         hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
         hint: You can instead skip this commit: run "git rebase --skip".
         hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
-        Could not apply 12ef546... second commit (fork)
+        Could not apply ac9f205... second commit (fork)
         Exit with 1 |}];
       print_status ();
       [%expect
@@ -96,7 +96,7 @@ type t =
             ; b : string
             ; c : float
             }
-          >>>>>>> 12ef546 (second commit (fork)):a.ml |}];
+          >>>>>>> ac9f205 (second commit (fork)):a.ml |}];
       resolve ();
       print_status ();
       [%expect
@@ -116,16 +116,16 @@ type t =
       system "git rebase --continue";
       [%expect
         {|
-        [detached HEAD 38f05c7] second commit (fork)
+        [detached HEAD 6a9624f] second commit (fork)
          1 file changed, 9 insertions(+), 6 deletions(-)
         Auto-merging b.ml
         CONFLICT (content): Merge conflict in b.ml
-        error: could not apply 7e70a06... third commit (fork)
+        error: could not apply 35725a2... third commit (fork)
         hint: Resolve all conflicts manually, mark them as resolved with
         hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
         hint: You can instead skip this commit: run "git rebase --skip".
         hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
-        Could not apply 7e70a06... third commit (fork)
+        Could not apply 35725a2... third commit (fork)
         Exit with 1 |}];
       print_status ();
       [%expect
@@ -137,7 +137,7 @@ type t =
         type b = int
 
 
-        >>>>>>> 7e70a06 (third commit (fork)):a.ml
+        >>>>>>> 35725a2 (third commit (fork)):a.ml
         type t =
           { a : int option
           ; b : string
@@ -167,6 +167,7 @@ type t =
           | A
           | B of int |}];
       system "git rebase --continue";
-      [%expect {|
-        [detached HEAD d0f3d71] third commit (fork)
+      [%expect
+        {|
+        [detached HEAD 392acaf] third commit (fork)
          1 file changed, 2 insertions(+) |}])

--- a/test/resolve2.ml
+++ b/test/resolve2.ml
@@ -43,12 +43,12 @@ type t =
         {|
         Auto-merging b.ml
         CONFLICT (content): Merge conflict in b.ml
-        error: could not apply a93a935... second commit (fork)
+        error: could not apply b60ee5f... second commit (fork)
         hint: Resolve all conflicts manually, mark them as resolved with
         hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
         hint: You can instead skip this commit: run "git rebase --skip".
         hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
-        Could not apply a93a935... second commit (fork)
+        Could not apply b60ee5f... second commit (fork)
         Exit with 1 |}];
       print_status ();
       [%expect
@@ -67,7 +67,7 @@ type t =
             b : string;
             c : float;
           }
-        >>>>>>> a93a935 (second commit (fork)):a.ml |}];
+        >>>>>>> b60ee5f (second commit (fork)):a.ml |}];
       resolve ();
       [%expect {| Resolved 1/1 b.ml |}];
       print_status ();
@@ -81,6 +81,7 @@ type t =
           ; d : unit option
           } |}];
       system "git rebase --continue";
-      [%expect {|
-        [detached HEAD 0a0bd2c] second commit (fork)
+      [%expect
+        {|
+        [detached HEAD e87f8c3] second commit (fork)
          1 file changed, 6 insertions(+), 6 deletions(-) |}])


### PR DESCRIPTION
I am under the impression that the tests can be affected by user and global git configuration, in addition to things like git version. This is an attempt to reduce the problem as much as possible.