### PR TITLE
Use `Filename.get_temp_dir_name` instead of `/tmp` for Windows compatibility

### DIFF
--- a/src/merge_cmd.ml
+++ b/src/merge_cmd.ml
@@ -2,7 +2,10 @@ open Base
 open Stdio
 open Common
 
-let debug_oc = lazy (Out_channel.create ~append:true "/tmp/merge-fmt.log")
+let debug_oc =
+  lazy
+    (Out_channel.create ~append:true
+       (Filename.concat (Filename.get_temp_dir_name ()) "merge-fmt.log"))
 
 let debug fmt =
   if true


### PR DESCRIPTION
We are thinking of switching to `ocamlformat` at LexiFi and have been experimenting with different potential workflows to handle the migration. In this context, I have been playing with this tool. However, since at LexiFi we don't use OPAM, big dependencies like `stdio` and `base` are inconvenient, so I did a small patch getting rid of this dependencies. If you are interested, you are welcome to integrate this!

Apart from the dependency issue there was a small portability bug: the use of `/tmp` on Windows is not correct, in this patch it is changed to `Filename.get_temp_dir_name()`.

Finally, note that the changes in this patch make the code 4.14-only (because they use the newly added `Out_channel`, `In_channel`, etc). If supporting old versions of OCaml is important for you, I think it should be doable to make a patch that supports old versions of OCaml (but I haven't tried it).